### PR TITLE
Fixed SQL injection exploit that allowed someone to alter the users table

### DIFF
--- a/website/save_profile.php
+++ b/website/save_profile.php
@@ -4,7 +4,7 @@ require_once('mysql_login.php');
 require_once('bad_words.php');
 
 function check_valid_organization($id) {
-  if ($id == 999) {
+  if ($id == 999 || !is_int($id)) {
     return False;
   }
   $query = "SELECT count(*) FROM organization where org_id=". $id;
@@ -16,7 +16,7 @@ function check_valid_organization($id) {
 }
 
 function check_valid_country($id) {
-  if ($id == 999) {
+  if ($id == 999 || !is_int($id)) {
     return False;
   }
   $query = "SELECT count(*) from country where country_id=". $id;


### PR DESCRIPTION
Fixed SQL injection exploit that allowed someone to alter the users table at will. For example, editing a profile's HTML and submitting the following as your country: 

9001 or 1=1 #' WHERE 1=1 #

Would change the id of everyone's country to 9001, and cause it to show up as "Unknown" on the server (the current beta server is an example, I just did this). Anything in the user table can be altered using this method. I've fixed this issue in save_profile.php by checking to see if the country and organization ids are integers.
