### PR TITLE
Update Scala starter bot to work with Scala 2.9.0-1

### DIFF
--- a/SCALA_LICENSE.txt
+++ b/SCALA_LICENSE.txt
@@ -1,0 +1,35 @@
+SCALA LICENSE
+
+Copyright (c) 2002-2011 EPFL, Lausanne, unless otherwise specified.
+All rights reserved.
+
+This software was developed by the Programming Methods Laboratory of the
+Swiss Federal Institute of Technology (EPFL), Lausanne, Switzerland.
+
+Permission to use, copy, modify, and distribute this software in source
+or binary form for any purpose with or without fee is hereby granted,
+provided that the following conditions are met:
+
+   1. Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+
+   2. Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+
+   3. Neither the name of the EPFL nor the names of its contributors
+      may be used to endorse or promote products derived from this
+      software without specific prior written permission.
+
+
+THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGE.

--- a/ants/dist/starter_bots/scala/AntsGame.scala
+++ b/ants/dist/starter_bots/scala/AntsGame.scala
@@ -4,7 +4,7 @@ import java.io._
 
 class AntsGame(in: InputStream = System.in, out: OutputStream = System.out) {
 
-  val source = Source.fromInputStream(in)
+  val source = new BufferedSource(in, Source.DefaultBufSize)
   val writer = new BufferedWriter(new OutputStreamWriter(out))
 
   def run(bot: Bot) = {

--- a/ants/dist/starter_bots/scala/AntsGame.scala
+++ b/ants/dist/starter_bots/scala/AntsGame.scala
@@ -10,7 +10,6 @@ class AntsGame(in: InputStream = System.in, out: OutputStream = System.out) {
   def run(bot: Bot) = {
     try {
 
-      @tailrec
       def playNextTurn(game: Game): Unit = {
         val newGameState = Parser.parse(source, game.parameters, game.board.water)
         if (newGameState.gameOver) Unit
@@ -28,5 +27,5 @@ class AntsGame(in: InputStream = System.in, out: OutputStream = System.out) {
       case t => t.printStackTrace
     }
   }
-  
+
 }

--- a/ants/dist/starter_bots/scala/BufferedSource.scala
+++ b/ants/dist/starter_bots/scala/BufferedSource.scala
@@ -1,0 +1,82 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___     Scala API                            **
+**    / __/ __// _ | / /  / _ |    (c) 2003-2011, LAMP/EPFL             **
+**  __\ \/ /__/ __ |/ /__/ __ |    http://scala-lang.org/               **
+** /____/\___/_/ |_/____/_/ | |                                         **
+**                          |/                                          **
+\*                                                                      */
+
+import java.io.{ InputStream, BufferedReader, InputStreamReader, PushbackReader }
+import scala.io._
+import Source.DefaultBufSize
+import scala.collection.Iterator
+
+/** This object provides convenience methods to create an iterable
+ *  representation of a source file.
+ *
+ *  @author  Burak Emir, Paul Phillips
+ */
+class BufferedSource(inputStream: InputStream, bufferSize: Int)(implicit val codec: Codec) extends Source {
+  def this(inputStream: InputStream)(implicit codec: Codec) = this(inputStream, DefaultBufSize)(codec)
+  def reader() = new InputStreamReader(inputStream, codec.decoder)
+  def bufferedReader() = new BufferedReader(reader(), bufferSize)
+  
+  // The same reader has to be shared between the iterators produced
+  // by iter and getLines. This is because calling hasNext can cause a
+  // block of data to be read from the stream, which will then be lost
+  // to getLines if it creates a new reader, even though next() was
+  // never called on the original.
+  private var charReaderCreated = false
+  private lazy val charReader = {
+    charReaderCreated = true
+    bufferedReader()
+  }
+  
+  override lazy val iter = (
+    Iterator
+    continually (codec wrap charReader.read())
+    takeWhile (_ != -1)
+    map (_.toChar)
+  )
+
+  class BufferedLineIterator extends Iterator[String] {
+    // Don't want to lose a buffered char sitting in iter either. Yes,
+    // this is ridiculous, but if I can't get rid of Source, and all the
+    // Iterator bits are designed into Source, and people create Sources
+    // in the repl, and the repl calls toString for the result line, and
+    // that calls hasNext to find out if they're empty, and that leads
+    // to chars being buffered, and no, I don't work here, they left a
+    // door unlocked.
+    private val lineReader: BufferedReader = {
+      // To avoid inflicting this silliness indiscriminately, we can
+      // skip it if the char reader was never created: and almost always
+      // it will not have been created, since getLines will be called
+      // immediately on the source.
+      if (charReaderCreated && iter.hasNext) {
+        val pb = new PushbackReader(charReader)
+        pb unread iter.next()
+        new BufferedReader(pb, bufferSize)
+      }
+      else charReader
+    }
+    var nextLine: String = null
+
+    override def hasNext = {
+      if (nextLine == null)
+        nextLine = lineReader.readLine
+      
+      nextLine != null
+    }
+    override def next(): String = {
+      val result = {
+        if (nextLine == null) lineReader.readLine
+        else try nextLine finally nextLine = null
+      }
+      if (result == null) Iterator.empty.next
+      else result
+    }
+  }
+
+  override def getLines(): Iterator[String] = new BufferedLineIterator
+}
+

--- a/ants/dist/starter_bots/scala/MyBot.scala
+++ b/ants/dist/starter_bots/scala/MyBot.scala
@@ -1,4 +1,4 @@
-object MyBot extends Application {
+object MyBot extends App {
   new AntsGame().run(new MyBot)
 }
 

--- a/ants/dist/starter_bots/scala/Parser.scala
+++ b/ants/dist/starter_bots/scala/Parser.scala
@@ -7,7 +7,6 @@ object Parser {
   def parse(source: Source, params: GameParameters = GameParameters(), knownWater: Map[Tile, Water] = Map.empty) = {
     val lines = source.getLines
 
-    @tailrec
     def parseInternal(state: GameInProgress): Game = {
       val line = lines.next.trim
       line match {

--- a/worker/compiler.py
+++ b/worker/compiler.py
@@ -357,7 +357,7 @@ languages = (
         [(["*.rb"], ChmodCompiler("Ruby"))]
     ),
     Language("Scala", ".scala", "MyBot.scala",
-        'JAVA_OPTS="-Xmx'+ str(MEMORY_LIMIT) +'m";scala -howtorun:object MyBot',
+        'scala -J-Xmx'+ str(MEMORY_LIMIT) +'m -howtorun:object MyBot',
         ["*.scala, *.jar"],
         [(["*.scala"], ExternalCompiler(comp_args["Scala"][0]))]
     ),


### PR DESCRIPTION
These commits make the starter bot work with Scala 2.9.0-1.  They include backporting BufferedSource from Scala master because a regression in Scala 2.9.0-1 caused the bot to never get all of its input from the game engine and thus always time out.
