### PR TITLE
Go starter package: fixed player_seed issue, refactored debugging, moved 

### DIFF
--- a/ants/dist/starter_bots/go/Makefile
+++ b/ants/dist/starter_bots/go/Makefile
@@ -5,6 +5,7 @@ GOFILES=\
 	ants.go\
 	map.go\
 	main.go\
+	debugging.go\
 	MyBot.go\
 
 include $(GOROOT)/src/Make.cmd

--- a/ants/dist/starter_bots/go/MyBot.go
+++ b/ants/dist/starter_bots/go/MyBot.go
@@ -3,8 +3,6 @@ package main
 import (
 	"os"
 	"rand"
-	"image"
-	//"fmt"
 )
 
 type MyBot struct {
@@ -16,31 +14,12 @@ func NewBot(s *State) Bot {
 	mb := &MyBot{
 	//do any necessary initialization here
 	}
-
 	return mb
 }
 
 //DoTurn is where you should do your bot's actual work.
 func (mb *MyBot) DoTurn(s *State) os.Error {
-
-	//for testing, if you want to see the map:
-	//fmt.Println(s.Map)
-
-	//if you want to visualize some data, I've provided a helper function.
-	//to use this, execute your bot with "-imgprefix xxxx" command line parameter,
-	//and then the following will get made into an image called xxxx.fieldofview.turn#.png
-	//You can output as many images as you want.
-	s.WriteDebugImage("fieldofview", func(row, col int) image.NRGBAColor {
-		//to construct an image.NRGBAColor, do this:
-		//return image.NRGBAColor{red, green, blue, alpha}
-		//where all four values are uint8's (0-255), and alpha represents transparency
-
-		//for now, we'll just return the default color for each item.
-		return s.Map.Item(s.Map.FromRowCol(row, col)).Color()
-	})
-
 	dirs := []Direction{North, East, South, West}
-
 	for loc, ant := range s.Map.Ants {
 		if ant != MY_ANT {
 			continue
@@ -58,9 +37,7 @@ func (mb *MyBot) DoTurn(s *State) os.Error {
 				break
 			}
 		}
-
 	}
-
 	//returning an error will halt the whole program!
 	return nil
 }

--- a/ants/dist/starter_bots/go/ants.go
+++ b/ants/dist/starter_bots/go/ants.go
@@ -26,7 +26,7 @@ type State struct {
 	ViewRadius2   int //view radius squared
 	AttackRadius2 int //battle radius squared
 	SpawnRadius2  int //spawn radius squared
-	PlayerSeed    int //random player seed
+	PlayerSeed    int64 //random player seed
 	Turn          int //current turn number
 
 	Map *Map
@@ -92,7 +92,7 @@ func (s *State) Start() os.Error {
 
 //Loop handles the majority of communication between your bot and the server.
 //b's DoWork function gets called each turn after the map has been setup
-//BetweenTurnWork gets called after a turn but before the map is reset. It is 
+//BetweenTurnWork gets called after a turn but before the map is reset. It is
 //meant to do debugging work.
 func (s *State) Loop(b Bot, BetweenTurnWork func()) os.Error {
 

--- a/ants/dist/starter_bots/go/ants.go
+++ b/ants/dist/starter_bots/go/ants.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"strings"
 	"fmt"
+	"log"
 )
 
 //Bot interface defines what we need from a bot
@@ -25,8 +26,8 @@ type State struct {
 	ViewRadius2   int //view radius squared
 	AttackRadius2 int //battle radius squared
 	SpawnRadius2  int //spawn radius squared
-
-	Turn int //current turn number
+	PlayerSeed    int //random player seed
+	Turn          int //current turn number
 
 	Map *Map
 }
@@ -74,13 +75,13 @@ func (s *State) Start() os.Error {
 			s.AttackRadius2 = param
 		case "spawnradius2":
 			s.SpawnRadius2 = param
-
+		case "player_seed":
+			s.PlayerSeed = param
 		case "turn":
 			s.Turn = param
 
 		default:
-			panic(1)
-			return os.NewError("unknown command: " + line)
+			log.Panicf("unknown command: %s", line)
 		}
 	}
 
@@ -104,7 +105,7 @@ func (s *State) Loop(b Bot, BetweenTurnWork func()) os.Error {
 			if err == os.EOF {
 				return err
 			}
-			Panicf("ReadString returns an error: %s", err)
+			log.Panicf("ReadString returns an error: %s", err)
 			return err
 		}
 		line = line[:len(line)-1] //remove the delimiter
@@ -131,19 +132,19 @@ func (s *State) Loop(b Bot, BetweenTurnWork func()) os.Error {
 
 		words := strings.Split(line, " ", 5)
 		if len(words) < 2 {
-			Panicf("Invalid command format: \"%s\"", line)
+			log.Panicf("Invalid command format: \"%s\"", line)
 		}
 
 		switch words[0] {
 		case "turn":
 			turn, _ := strconv.Atoi(words[1])
 			if turn != s.Turn+1 {
-				Panicf("Turn number out of sync, expected %v got %v", s.Turn+1, turn)
+				log.Panicf("Turn number out of sync, expected %v got %v", s.Turn+1, turn)
 			}
 			s.Turn = turn
 		case "f":
 			if len(words) < 3 {
-				Panicf("Invalid command format (not enough parameters for food): \"%s\"", line)
+				log.Panicf("Invalid command format (not enough parameters for food): \"%s\"", line)
 			}
 			Row, _ := strconv.Atoi(words[1])
 			Col, _ := strconv.Atoi(words[2])
@@ -151,7 +152,7 @@ func (s *State) Loop(b Bot, BetweenTurnWork func()) os.Error {
 			s.Map.AddFood(loc)
 		case "w":
 			if len(words) < 3 {
-				Panicf("Invalid command format (not enough parameters for water): \"%s\"", line)
+				log.Panicf("Invalid command format (not enough parameters for water): \"%s\"", line)
 			}
 			Row, _ := strconv.Atoi(words[1])
 			Col, _ := strconv.Atoi(words[2])
@@ -159,7 +160,7 @@ func (s *State) Loop(b Bot, BetweenTurnWork func()) os.Error {
 			s.Map.AddWater(loc)
 		case "a":
 			if len(words) < 4 {
-				Panicf("Invalid command format (not enough parameters for ant): \"%s\"", line)
+				log.Panicf("Invalid command format (not enough parameters for ant): \"%s\"", line)
 			}
 			Row, _ := strconv.Atoi(words[1])
 			Col, _ := strconv.Atoi(words[2])
@@ -175,7 +176,7 @@ func (s *State) Loop(b Bot, BetweenTurnWork func()) os.Error {
 			}
 		case "d":
 			if len(words) < 4 {
-				Panicf("Invalid command format (not enough parameters for dead ant): \"%s\"", line)
+				log.Panicf("Invalid command format (not enough parameters for dead ant): \"%s\"", line)
 			}
 			Row, _ := strconv.Atoi(words[1])
 			Col, _ := strconv.Atoi(words[2])

--- a/ants/dist/starter_bots/go/debugging.go
+++ b/ants/dist/starter_bots/go/debugging.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"fmt"
+	"flag"
+	"log"
+	"os"
+	"image"
+	"image/png"
+)
+
+//I added a mechanism to make customizing image output a lot easier, see
+//the use of WriteDebugImage in MyBot.go
+//I'll leave this here for reference, since it works also
+/*if *imageOutPrefix != "" {
+    fname := fmt.Sprintf("%s.%d.png", *imageOutPrefix, s.Turn)
+    //fmt.Printf("making image: %s\n", fname)
+    f, err := os.Open(fname, os.O_WRONLY | os.O_CREATE, 0666)
+    if err != nil {
+        log.Panicf("Couldn't open %s (%s)", fname, err)
+    }
+    defer f.Close()
+    err = png.Encode(f, s.Map)
+    if err != nil {
+        log.Panicf("Couldn't encode png (%s)", err)
+    }
+}*/
+
+type ImageHelper struct {
+	m     *Map
+	pixel func(row, col int) image.NRGBAColor
+}
+
+func (ih ImageHelper) ColorModel() image.ColorModel {
+	return image.NRGBAColorModel
+}
+func (ih ImageHelper) Bounds() image.Rectangle {
+	return image.Rect(0, 0, ih.m.Cols*4, ih.m.Rows*4)
+}
+func (ih ImageHelper) At(x, y int) image.Color {
+	return ih.pixel(y/4, x/4)
+}
+func (s *State) WriteDebugImage(Desc string, At func(row, col int) image.NRGBAColor) {
+
+	//use -imgprefix="bot0" to make a series of images (bot0.0.png ... bot0.N.png) which
+	//illustrate the bot's knowledge of the map at each turn. If you want the images in a
+	//subdirectory, make sure you create the directory first. (e.g., -imgprefix="images/bot0")
+	imageOutPrefix := flag.String("imgprefix", "", "prefix for helpful debugging images")
+
+	if imageOutPrefix == nil {
+		return
+	}
+
+	fname := fmt.Sprintf("%s.%s.%3.3d.png", *imageOutPrefix, Desc, s.Turn)
+	//fmt.Printf("making image: %s\n", fname)
+	f, err := os.OpenFile(fname, os.O_WRONLY|os.O_CREATE, 0666)
+	if err != nil {
+		log.Panicf("Couldn't open %s (%s)", fname, err)
+	}
+	defer f.Close()
+	err = png.Encode(f, ImageHelper{s.Map, At})
+	if err != nil {
+		log.Panicf("Couldn't encode png (%s)", err)
+	}
+}
+
+func (o Item) Color() image.NRGBAColor {
+	switch o {
+	case UNKNOWN:
+		return image.NRGBAColor{0xb0, 0xb0, 0xb0, 0xff}
+	case WATER:
+		return image.NRGBAColor{0x10, 0x10, 0x50, 0xff}
+	case FOOD:
+		return image.NRGBAColor{0xe0, 0xe0, 0xc0, 0xff}
+	case LAND:
+		return image.NRGBAColor{0x8b, 0x45, 0x13, 0xff}
+	case DEAD:
+		return image.NRGBAColor{0x69, 0x33, 0x05, 0xff}
+	case MY_ANT:
+		return image.NRGBAColor{0xf0, 0x00, 0x00, 0xff}
+	case PLAYER1:
+		return image.NRGBAColor{0xf0, 0xf0, 0x00, 0xff}
+	case PLAYER2:
+		return image.NRGBAColor{0x00, 0xf0, 0x00, 0xff}
+	case PLAYER3:
+		return image.NRGBAColor{0x00, 0x00, 0xf0, 0xff}
+	case PLAYER4:
+		return image.NRGBAColor{0xf0, 0x00, 0xf0, 0xff}
+	case PLAYER5:
+		return image.NRGBAColor{0xf0, 0xf0, 0xf0, 0xff}
+	case PLAYER6:
+		return image.NRGBAColor{0x80, 0x80, 0x00, 0xff}
+	case PLAYER7:
+		return image.NRGBAColor{0x00, 0x80, 0x80, 0xff}
+	case PLAYER8:
+		return image.NRGBAColor{0x80, 0x00, 0x80, 0xff}
+	case PLAYER9:
+		return image.NRGBAColor{0x80, 0x00, 0xf0, 0xff}
+	}
+	return image.NRGBAColor{0x00, 0x00, 0x00, 0xff}
+}
+
+//implement Image for fancy image debugging
+func (m *Map) ColorModel() image.ColorModel {
+	return image.NRGBAColorModel
+}
+func (m *Map) Bounds() image.Rectangle {
+	return image.Rect(0, 0, m.Cols*4, m.Rows*4)
+}
+func (m *Map) At(x, y int) image.Color {
+	loc := m.FromRowCol(y/4, x/4)
+	return m.itemGrid[loc].Color()
+}

--- a/ants/dist/starter_bots/go/main.go
+++ b/ants/dist/starter_bots/go/main.go
@@ -1,105 +1,22 @@
 package main
 
 import (
-	"flag"
-	"image"
-	"image/png"
 	"os"
-	"fmt"
+	"log"
 )
-
-//use -imgprefix="bot0" to make a series of images (bot0.0.png ... bot0.N.png) which
-//illustrate the bot's knowledge of the map at each turn. If you want the images in a
-//subdirectory, make sure you create the directory first. (e.g., -imgprefix="images/bot0")
-var imageOutPrefix *string = flag.String("imgprefix", "", "prefix for helpful debugging images")
-
-//runs a test to make sure the map object does what we expect
-var runTests *bool = flag.Bool("test-suite", false, "set this to run the tests")
-
-
-//call Panicf to halt the program with a stack trace. Use it like fmt.Sprintf
-func Panicf(format string, args ...interface{}) {
-	panic(fmt.Sprintf(format, args...))
-}
-
-
-type ImageHelper struct {
-	m     *Map
-	pixel func(row, col int) image.NRGBAColor
-}
-
-func (ih ImageHelper) ColorModel() image.ColorModel {
-	return image.NRGBAColorModel
-}
-func (ih ImageHelper) Bounds() image.Rectangle {
-	return image.Rect(0, 0, ih.m.Cols*4, ih.m.Rows*4)
-}
-func (ih ImageHelper) At(x, y int) image.Color {
-	return ih.pixel(y/4, x/4)
-}
-func (s *State) WriteDebugImage(Desc string, At func(row, col int) image.NRGBAColor) {
-	if imageOutPrefix == nil {
-		return
-	}
-
-	fname := fmt.Sprintf("%s.%s.%3.3d.png", *imageOutPrefix, Desc, s.Turn)
-	//fmt.Printf("making image: %s\n", fname)
-	f, err := os.OpenFile(fname, os.O_WRONLY|os.O_CREATE, 0666)
-	if err != nil {
-		Panicf("Couldn't open %s (%s)", fname, err)
-	}
-	defer f.Close()
-	err = png.Encode(f, ImageHelper{s.Map, At})
-	if err != nil {
-		Panicf("Couldn't encode png (%s)", err)
-	}
-}
-
 
 //main initializes the state and starts the processing loop
 func main() {
 	var s State
-
-	flag.Parse()
-
-	if *runTests {
-		//We can't use go's built-in test framework for the main package,
-		//and we can't split it into separate packages because the contest doesn't use makefiles.
-		//(I did provide a makefile for your convienience, though)
-		TestMap()
-		return
-	}
-
 	err := s.Start()
 	if err != nil {
-		Panicf("Start() failed (%s)", err)
+		log.Panicf("Start() failed (%s)", err)
 	}
-
 	mb := NewBot(&s)
-
 	err = s.Loop(mb, func() {
-
-		//I added a mechanism to make customizing image output a lot easier, see
-		//the use of WriteDebugImage in MyBot.go
-		//I'll leave this here for reference, since it works also
-		/*if *imageOutPrefix != "" {
-			fname := fmt.Sprintf("%s.%d.png", *imageOutPrefix, s.Turn)
-			//fmt.Printf("making image: %s\n", fname)
-			f, err := os.Open(fname, os.O_WRONLY | os.O_CREATE, 0666)
-			if err != nil {
-				Panicf("Couldn't open %s (%s)", fname, err)
-			}
-			defer f.Close()
-			err = png.Encode(f, s.Map)
-			if err != nil {
-				Panicf("Couldn't encode png (%s)", err)
-			}
-		}*/
-
 		//if you want to do other between-turn debugging things, you can do them here
 	})
-
 	if err != nil && err != os.EOF {
-		Panicf("Loop() failed (%s)", err)
+		log.Panicf("Loop() failed (%s)", err)
 	}
 }

--- a/ants/dist/starter_bots/go/map.go
+++ b/ants/dist/starter_bots/go/map.go
@@ -1,8 +1,7 @@
 package main
 
 import (
-	"image"
-	"fmt"
+	"log"
 )
 
 //Item represents all the various items that may be on the map
@@ -58,7 +57,7 @@ func (o Item) Symbol() byte {
 	}
 
 	if o < MY_ANT || o > PLAYER25 {
-		Panicf("invalid item: %v", o)
+		log.Panicf("invalid item: %v", o)
 	}
 
 	return byte(o) + 'a'
@@ -79,46 +78,11 @@ func FromSymbol(ch byte) Item {
 		return DEAD
 	}
 	if ch < 'a' || ch > 'z' {
-		Panicf("invalid item symbol: %v", ch)
+		log.Panicf("invalid item symbol: %v", ch)
 	}
 	return Item(ch) + 'a'
 }
 
-func (o Item) Color() image.NRGBAColor {
-	switch o {
-	case UNKNOWN:
-		return image.NRGBAColor{0xb0, 0xb0, 0xb0, 0xff}
-	case WATER:
-		return image.NRGBAColor{0x10, 0x10, 0x50, 0xff}
-	case FOOD:
-		return image.NRGBAColor{0xe0, 0xe0, 0xc0, 0xff}
-	case LAND:
-		return image.NRGBAColor{0x8b, 0x45, 0x13, 0xff}
-	case DEAD:
-		return image.NRGBAColor{0x69, 0x33, 0x05, 0xff}
-	case MY_ANT:
-		return image.NRGBAColor{0xf0, 0x00, 0x00, 0xff}
-	case PLAYER1:
-		return image.NRGBAColor{0xf0, 0xf0, 0x00, 0xff}
-	case PLAYER2:
-		return image.NRGBAColor{0x00, 0xf0, 0x00, 0xff}
-	case PLAYER3:
-		return image.NRGBAColor{0x00, 0x00, 0xf0, 0xff}
-	case PLAYER4:
-		return image.NRGBAColor{0xf0, 0x00, 0xf0, 0xff}
-	case PLAYER5:
-		return image.NRGBAColor{0xf0, 0xf0, 0xf0, 0xff}
-	case PLAYER6:
-		return image.NRGBAColor{0x80, 0x80, 0x00, 0xff}
-	case PLAYER7:
-		return image.NRGBAColor{0x00, 0x80, 0x80, 0xff}
-	case PLAYER8:
-		return image.NRGBAColor{0x80, 0x00, 0x80, 0xff}
-	case PLAYER9:
-		return image.NRGBAColor{0x80, 0x00, 0xf0, 0xff}
-	}
-	return image.NRGBAColor{0x00, 0x00, 0x00, 0xff}
-}
 
 //Location combines (Row, Col) coordinate pairs for use as keys in maps (and in a 1d array)
 type Location int
@@ -227,7 +191,7 @@ func (m *Map) AddFood(loc Location) {
 
 func (m *Map) AddDestination(loc Location) {
 	if m.Destinations[loc] {
-		Panicf("Already have something at that destination!")
+		log.Panicf("Already have something at that destination!")
 	}
 	m.Destinations[loc] = true
 }
@@ -274,18 +238,6 @@ func (m *Map) FromLocation(loc Location) (Row, Col int) {
 	return
 }
 
-//implement Image for fancy image debugging
-func (m *Map) ColorModel() image.ColorModel {
-	return image.NRGBAColorModel
-}
-func (m *Map) Bounds() image.Rectangle {
-	return image.Rect(0, 0, m.Cols*4, m.Rows*4)
-}
-func (m *Map) At(x, y int) image.Color {
-	loc := m.FromRowCol(y/4, x/4)
-	return m.itemGrid[loc].Color()
-}
-
 
 //Direction represents the direction concept for issuing orders.
 type Direction int
@@ -312,7 +264,7 @@ func (d Direction) String() string {
 	case NoMovement:
 		return "-"
 	}
-	Panicf("%v is not a valid direction", d)
+	log.Panicf("%v is not a valid direction", d)
 	return ""
 }
 
@@ -330,67 +282,7 @@ func (m *Map) Move(loc Location, d Direction) Location {
 		Col += 1
 	case NoMovement: //do nothing
 	default:
-		Panicf("%v is not a valid direction", d)
+		log.Panicf("%v is not a valid direction", d)
 	}
 	return m.FromRowCol(Row, Col) //this will handle wrapping out-of-bounds numbers
-}
-
-
-//a few test functions
-func TestMap() {
-	m := NewMap(4, 3)
-
-	m.Reset()
-
-	if m.String() != `. . . 
-. . . 
-. . . 
-. . . 
-` {
-		Panicf("map is wrong size, got `%s`", m)
-	}
-
-	loc := m.FromRowCol(3, 2)
-	row, col := m.FromLocation(loc)
-
-	if row != 3 || col != 2 {
-		Panicf("conversion broken, got (%v, %v), wanted (3, 2)", row, col)
-	}
-
-	loc2 := m.FromRowCol(3, -1)
-
-	if loc2 != loc {
-		Panicf("from xy broken, got (%v), wanted (%v)", loc2, loc)
-	}
-
-	n := m.FromRowCol(2, 2)
-	s := m.FromRowCol(4, 2)
-	e := m.FromRowCol(3, 3)
-	w := m.FromRowCol(3, 1)
-
-	if n != m.Move(loc, North) {
-		Panicf("Move north is broken")
-	}
-	if s != m.Move(loc, South) {
-		Panicf("Move south is broken")
-	}
-	if e != m.Move(loc, East) {
-		Panicf("Move east is broken")
-	}
-	if w != m.Move(loc, West) {
-		Panicf("Move west is broken")
-	}
-
-	m.AddAnt(n, MY_ANT)
-	m.AddAnt(s, MY_ANT)
-
-	if m.String() != `. . a 
-. . . 
-. . a 
-. . . 
-` {
-		Panicf("map put ants in wrong place, got `%s`", m)
-	}
-
-	fmt.Println("TestMap PASS")
 }

--- a/ants/dist/starter_bots/go/map_test.go
+++ b/ants/dist/starter_bots/go/map_test.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestMap(t *testing.T) {
+	m := NewMap(4, 3)
+	m.Reset()
+	if m.String() != `. . . 
+. . . 
+. . . 
+. . . 
+` {
+		t.Errorf("map is wrong size, got `%s`", m)
+	}
+
+	loc := m.FromRowCol(3, 2)
+	row, col := m.FromLocation(loc)
+	if row != 3 || col != 2 {
+		t.Errorf("conversion broken, got (%v, %v), wanted (3, 2)", row, col)
+	}
+
+	loc2 := m.FromRowCol(3, -1)
+	if loc2 != loc {
+		t.Errorf("from xy broken, got (%v), wanted (%v)", loc2, loc)
+	}
+
+	n := m.FromRowCol(2, 2)
+	s := m.FromRowCol(4, 2)
+	e := m.FromRowCol(3, 3)
+	w := m.FromRowCol(3, 1)
+
+	if n != m.Move(loc, North) {
+		t.Errorf("Move north is broken")
+	}
+	if s != m.Move(loc, South) {
+		t.Errorf("Move south is broken")
+	}
+	if e != m.Move(loc, East) {
+		t.Errorf("Move east is broken")
+	}
+	if w != m.Move(loc, West) {
+		t.Errorf("Move west is broken")
+	}
+
+	m.AddAnt(n, MY_ANT)
+	m.AddAnt(s, MY_ANT)
+
+	if m.String() != `. . a 
+. . . 
+. . a 
+. . . 
+` {
+		t.Errorf("map put ants in wrong place, got `%s`", m)
+	}
+}


### PR DESCRIPTION
Go starter package: fixed player_seed issue, refactored debugging, moved tests.

Use log.Panicf instead of defining your own function.
Fixed player_seed bug.
Image debugging should stay in a separte file since it's not really that useful
for everybody.
Use gotest to run tests.
Move TestMap to map_test.go so it can be found by gotest.
