### PR TITLE
use -O2 optimizations with ghc

### DIFF
--- a/worker/compiler.py
+++ b/worker/compiler.py
@@ -317,7 +317,7 @@ comp_args = {
                              ["jar", "cfe", BOT + ".jar", BOT]],
     # If we ever upgrade to GHC 7, we will need to add -rtsopts to this command
     # in order for the maximum heap size RTS flag to work on the executable.
-    "Haskell" : [["ghc", "--make", BOT + ".hs", "-O", "-v0"]],
+    "Haskell" : [["ghc", "--make", BOT + ".hs", "-O2", "-v0"]],
     "Java"        : [["javac", "-J-Xmx%sm" % (MEMORY_LIMIT)],
                              ["jar", "cfe", BOT + ".jar", BOT]],
     "Lisp"      : [['sbcl', '--dynamic-space-size', str(MEMORY_LIMIT), '--script', BOT + '.lisp']],


### PR DESCRIPTION
Any reason why the Haskell options had only -O enabled? -O2 should still only contain "safe" optimizations, and might help a lot in some cases (e.g. I don't think -O does any cross-module optimization whatsoever).
