### PR TITLE
Support for compiling Python and Python3 extension modules.

### DIFF
--- a/worker/compiler.py
+++ b/worker/compiler.py
@@ -303,7 +303,7 @@ class TargetCompiler(Compiler):
 
 PYTHON_EXT_COMPILER = '''"from distutils.core import setup
 from distutils.extension import read_setup_file
-setup(ext_modules = read_setup_file('Setup'), script_args = ['-q', 'build_ext', '-i'])"'''
+setup(ext_modules = read_setup_file('Setup_exts'), script_args = ['-q', 'build_ext', '-i'])"'''
 
 comp_args = {
     # lang : ([list of compilation arguments], ...)
@@ -487,13 +487,13 @@ languages = (
         "python MyBot.py",
         ["*.pyc"],
         [(["*.py"], ChmodCompiler("Python")),
-        (["Setup"], ErrorFilterCompiler(comp_args["Python"][0], separate=True, filter_stderr='-Wstrict-prototypes'))]
+        (["Setup_exts"], ErrorFilterCompiler(comp_args["Python"][0], separate=True, filter_stderr='-Wstrict-prototypes'))]
     ),
     Language("Python3", BOT +".py3", "MyBot.py3",
         "python3 MyBot.py3",
         ["*.pyc"],
         [(["*.py3"], ChmodCompiler("Python3")),
-        (["Setup"], ErrorFilterCompiler(comp_args["Python3"][0], separate=True, filter_stderr='-Wstrict-prototypes'))]
+        (["Setup_exts"], ErrorFilterCompiler(comp_args["Python3"][0], separate=True, filter_stderr='-Wstrict-prototypes'))]
     ),
     Language("Ruby", BOT +".rb", "MyBot.rb",
         "ruby MyBot.rb",

--- a/worker/compiler.py
+++ b/worker/compiler.py
@@ -301,6 +301,10 @@ class TargetCompiler(Compiler):
             box.release()
         return True
 
+PYTHON_EXT_COMPILER = '''"from distutils.core import setup
+from distutils.extension import read_setup_file
+setup(ext_modules = read_setup_file('Setup'), script_args = ['-q', 'build_ext', '-i'])"'''
+
 comp_args = {
     # lang : ([list of compilation arguments], ...)
     #                If the compilation should output each source file to
@@ -330,6 +334,8 @@ comp_args = {
     "Lisp"      : [['sbcl', '--dynamic-space-size', str(MEMORY_LIMIT), '--script', BOT + '.lisp']],
     "OCaml"     : [["ocamlbuild -lib unix", BOT + ".native"]],
     "Pascal"    : [["fpc", "-Mdelphi", "-Si", "-O3", "-Xs", "-v0", "-o" + BOT]],
+    "Python"    : [["python", "-c", PYTHON_EXT_COMPILER]],
+    "Python3"   : [["python3", "-c", PYTHON_EXT_COMPILER]],
     "Scala"     : [["scalac"]],
     }
 
@@ -480,12 +486,14 @@ languages = (
     Language("Python", BOT +".py", "MyBot.py",
         "python MyBot.py",
         ["*.pyc"],
-        [(["*.py"], ChmodCompiler("Python"))]
+        [(["*.py"], ChmodCompiler("Python")),
+        (["Setup"], ErrorFilterCompiler(comp_args["Python"][0], separate=True, filter_stderr='-Wstrict-prototypes'))]
     ),
     Language("Python3", BOT +".py3", "MyBot.py3",
         "python3 MyBot.py3",
         ["*.pyc"],
-        [(["*.py3"], ChmodCompiler("Python3"))]
+        [(["*.py3"], ChmodCompiler("Python3")),
+        (["Setup"], ErrorFilterCompiler(comp_args["Python3"][0], separate=True, filter_stderr='-Wstrict-prototypes'))]
     ),
     Language("Ruby", BOT +".rb", "MyBot.rb",
         "ruby MyBot.rb",


### PR DESCRIPTION
The modules should be described using a standard Setup file. Each line of the file describes an extension, eg.
my_extension my_extension.c somelib.cpp

Hi, how's this? I also wrote an alternative implementation which calls gcc manually, and compiles all C/C++ files named extname.*.ext to extname.so instead of using a Setup file. However it did not support support Python3 and was considerably more complex. I think this way is much better.
