### PR TITLE
Enable Scala continuation support

### DIFF
--- a/worker/compiler.py
+++ b/worker/compiler.py
@@ -336,7 +336,7 @@ comp_args = {
     "Pascal"    : [["fpc", "-Mdelphi", "-Si", "-O3", "-Xs", "-v0", "-o" + BOT]],
     "Python"    : [["python", "-c", PYTHON_EXT_COMPILER]],
     "Python3"   : [["python3", "-c", PYTHON_EXT_COMPILER]],
-    "Scala"     : [["scalac"]],
+    "Scala"     : [["scalac", "-P:continuations:enable"]],
     }
 
 targets = {


### PR DESCRIPTION
Added the -P:continuations:enable flag to the scalac command line to enable the continuation plugin (included since Scala 2.8). This shouldn't affect any code that doesn't import anything from scala.util.continuations. Code that does won't work without this flag.
