### PR TITLE
Clojure bots are crashing in Math/abs (called in 'direction') because

### DIFF
--- a/ants/dist/starter_bots/clojure/ants.clj
+++ b/ants/dist/starter_bots/clojure/ants.clj
@@ -66,7 +66,7 @@
     (if (message? :ready cur)
       info
       (let [[k v] (string/split cur #" ")
-            neue (assoc info (keyword k) (BigInteger. v))]
+            neue (assoc info (keyword k) (Long/parseLong v))]
         (recur (read-line) neue)))))
 
 (defn- get-turn [msg]


### PR DESCRIPTION
Math/abs doesn't cope with BigInteger values; let's just use Longs
instead.
