### PR TITLE
Fix Java/CoffeeScript bugs when input chunks end in the middle of a line.

### DIFF
--- a/ants/dist/starter_bots/coffeescript/ants.coffee
+++ b/ants/dist/starter_bots/coffeescript/ants.coffee
@@ -59,10 +59,19 @@ class Game
 
   # The main game loop
   run: (bot) ->
+    partialline = ""
     process.stdin.resume()
     process.stdin.setEncoding('utf8')
     process.stdin.on 'data', (chunk) =>
       lines = chunk.split("\n")
+      # Append possible partial line
+      lines[0] = partialline + lines[0]
+      partialline = ""
+      # If the last line is complete, there should be an
+      # empy string at the end of the array
+      if lines[lines.length-1] != ""
+        partialline = lines[lines.length-1]
+        lines = lines[0...lines.length-1]
       for line in lines
         state = @parse line.trim()
         switch state

--- a/ants/dist/starter_bots/javascript/Ants.js
+++ b/ants/dist/starter_bots/javascript/Ants.js
@@ -29,10 +29,10 @@ exports.ants = {
 			partialline = "";
 			// Complete lines will leave an empty
 			// string at the end, if that is not the case
-		        // buffer this line until the next chunk
+			// buffer this line until the next chunk
 			if (lines[lines.length - 1] !== "") {
-			    partialline = lines[lines.length - 1];
-			    lines = lines.slice(0, lines.length - 1);
+				partialline = lines[lines.length - 1];
+				lines.splice(lines.length - 1, 1);
 			}
 			for (var i = 0, len = lines.length; i < len; ++i) {
 				thisoutside.processLine(lines[i]);

--- a/ants/dist/starter_bots/javascript/Ants.js
+++ b/ants/dist/starter_bots/javascript/Ants.js
@@ -19,11 +19,21 @@ exports.ants = {
 	},
 	'start': function(botInput) {
 		this.bot = botInput;
+		var partialline = "";
 		process.stdin.resume();
 		process.stdin.setEncoding('utf8');
 		var thisoutside = this;
 		process.stdin.on('data', function(chunk) {
 			var lines = chunk.split("\n");
+			lines[0] = partialline + lines[0];
+			partialline = "";
+			// Complete lines will leave an empty
+			// string at the end, if that is not the case
+		        // buffer this line until the next chunk
+			if (lines[lines.length - 1] !== "") {
+			    partialline = lines[lines.length - 1];
+			    lines = lines.slice(0, lines.length - 1);
+			}
 			for (var i = 0, len = lines.length; i < len; ++i) {
 				thisoutside.processLine(lines[i]);
 			}


### PR DESCRIPTION
There is a bug in all node.js based bots: they are parsing input on the assumption that they are always given complete lines, but there is no such guarantee in node.js. 

As a result, they can occasionally get stuck (if the line is split in the middle of the "go" command, which requires "luck") or start to order the wrong ants around (if the line is split between the ant and the ant color).

I did some basic testing that this runs and fixes the issue.
