### PR TITLE
C starter pack: bug in map wrap calculation

### DIFF
--- a/ants/dist/starter_bots/c/YourCode.c
+++ b/ants/dist/starter_bots/c/YourCode.c
@@ -54,7 +54,7 @@ void do_turn(struct game_state *Game, struct game_info *Info) {
         if (COL != Info->cols - 1)
             obj_east = Info->map[offset + RIGHT];
         else
-            obj_east = Info->map[offset - Info->cols - 1];
+            obj_east = Info->map[offset - Info->cols + 1];
 
         if (ROW != 0)
             obj_north = Info->map[offset + UP];


### PR DESCRIPTION
It looks to me like there's an occasional problem calculating the offset of objects to the east.

In the worst case the map index can become negative.
