### PR TITLE
Fix: use TimeSpan.TotalMilliseconds instead of TimeSpan.Milliseconds to ...

### DIFF
--- a/ants/dist/starter_bots/csharp/GameState.cs
+++ b/ants/dist/starter_bots/csharp/GameState.cs
@@ -15,7 +15,7 @@ namespace Ants {
 		public int TimeRemaining {
 			get {
 				TimeSpan timeSpent = DateTime.Now - turnStart;
-				return TurnTime - timeSpent.Milliseconds;
+				return TurnTime - (int)timeSpent.TotalMilliseconds;
 			}
 		}
 


### PR DESCRIPTION
...measure the time in C# starter bot
