### PR TITLE
Update Dart support for dart-frogsh-r1499-2

### DIFF
--- a/setup/worker_setup.py
+++ b/setup/worker_setup.py
@@ -83,8 +83,8 @@ def install_dart(download_base):
         return
     with CD("/root"):
         run_cmd("curl '%s/dart.tgz' | tar xz" % (download_base,))
-        os.rename("dart-frogsh-r1499", "/usr/share/dart")
-        os.symlink("/usr/share/dart/frogsh", "/usr/bin/frogsh")
+        os.rename("dart-frogsh-r1499-2", "/usr/share/dart")
+        os.symlink("/usr/share/dart/frog/frogsh", "/usr/bin/frogsh")
 
 def install_groovy(download_base):
     """ Install the Groovy language """


### PR DESCRIPTION
Fixes error where frogsh couldn't run due to missing corelib files.

Also requires that someone manually copy

http://ants-dart-starter-package.googlecode.com/files/dart-frogsh-r1499-2.tgz

to the server's download_base directory.

The dart-frogsh-r1499-2.tgz file should be named dart.tgz when it is placed in the server's
download_base directory.
