### PR TITLE
Update dart starter package and frogsh compiler to avoid writing to stdout

### DIFF
--- a/ants/dist/starter_bots/dart/Ants.dart
+++ b/ants/dist/starter_bots/dart/Ants.dart
@@ -2,6 +2,12 @@
 
 #import("lib/node/node.dart");
 
+// Write to stderr because stdin and stdout are in use.
+
+void log(String msg) {
+  console.error(msg);
+}
+
 interface Bot {
   void onReady();
   void onTurn();
@@ -132,7 +138,8 @@ class Ants {
 
 	void processLine(String inLine) {
 		this.vision = false;
-		List<Strings> line = inLine.trim().split(' ');
+		String trimmed = inLine.trim();
+		List<String> line = trimmed.split(' ');
 
 		if (line[0] === 'ready') {
 			Tile land = new Tile(LAND);
@@ -318,9 +325,9 @@ class Ants {
 				this.map[row][col].type === DEAD);
 	}
 
-	int destination(int row, int col, String direction) {
-		var rowd = 0;
-		var cold = 0;
+	List<int> destination(int row, int col, String direction) {
+		int rowd = 0;
+		int cold = 0;
 		if (direction === 'N') {
 			rowd = -1;
 		} else if (direction === 'E') {
@@ -330,8 +337,8 @@ class Ants {
 		} else if (direction === 'W') {
 			cold = -1;
 		}
-		var newrow = row + rowd;
-		var newcol = col + cold;
+		int newrow = row + rowd;
+		int newcol = col + cold;
 		if (newrow < 0) {
 			newrow = this.config.rows-1;
 		} else if (newrow > this.config.rows-1) {

--- a/ants/dist/starter_bots/dart/lib/node/node.dart
+++ b/ants/dist/starter_bots/dart/lib/node/node.dart
@@ -67,6 +67,7 @@ class process native "process" {
   // TODO(nweiz): add Stream type information
   static ReadableStream stdin;
   static WriteableStream stdout;
+  static String version;
 
   static void exit([int code = 0]) native;
   static String cwd() native;
@@ -74,6 +75,8 @@ class process native "process" {
 
 class ReadableStream native "ReadableStream" {
   void resume() native;
+  void setEncoding(String encoding) native;
+  void on(String event, Function listener) native;
 }
 
 class WriteableStream native "WriteableStream" {


### PR DESCRIPTION
This time I think it's going to work. (I've installed it on a VM version of the aichallenge server and it seems
to be working there. At least the sanity tests are passing.)

The previous code had two problems:
1) The dart starter kit had some type warnings.
2) The dart-frogsh compiler wrote those type warnings to stdout, which ment that
    a) the program would fail the sanity tests.
    b) the user didn't see the warnings or error messages (because they were written to stdout.)

Fixed by:

1) Modifying the frogsh compiler to write warnings and messages to stderr.

2) Fixing the type warnings in the dart starter kit.

3) Adding a convenience function to log to stderr.

Note: Someone will have to manually update the dart frogsh compiler by manually installing:

http://ants-dart-starter-package.googlecode.com/files/dart-frogsh-r1499.tgz

in the aichallenge server download_dir
