### PR TITLE
worker sometimes crashes due to unitialised variable

### DIFF
--- a/worker/engine.py
+++ b/worker/engine.py
@@ -404,6 +404,7 @@ def get_moves(game, bots, bot_nums, time_limit, turn):
             continue # bot is dead
 
         line = bot.read_line()
+	lines_read = 0;
         while line is not None and len(bot_moves[b]) < 40000:
             line = line.strip()
             if line.lower() == 'go':


### PR DESCRIPTION
there is a variable in the worker that is incremented before it has been initialised.
