### PR TITLE
Obfuscate document.activeElement in cases document doesn't exist (#390)

### DIFF
--- a/ants/visualizer/js/Application.js
+++ b/ants/visualizer/js/Application.js
@@ -740,7 +740,7 @@ Visualizer.prototype.tryStart = function() {
 			 * @returns {Boolean} True, if the browser should handle the event.
 			 */
 			document.onkeydown = function(event) {
-				if (!(event.shiftKey || event.ctrlKey || event.altKey || event.metaKey || document.activeElement.tagName == "INPUT")) {
+				if (!(event.shiftKey || event.ctrlKey || event.altKey || event.metaKey || (document.activeElement || {}).tagName == "INPUT")) {
 					if (Visualizer.focused.keyPressed(event.keyCode)) {
 						if (event.preventDefault)
 							event.preventDefault();


### PR DESCRIPTION
Should fix the crash with the java visualizer
